### PR TITLE
[SPD-11151] fix env var typo - bump fallback version

### DIFF
--- a/build
+++ b/build
@@ -12,11 +12,11 @@ cd "$(dirname "$0")"
 
 VERSION=$(speedmgmt version | awk '{printf $3}')
 VERSION=${VERSION:1}
-NETAPP_VERSION=${NETAPP_VERSION:-"v0.0.5"}
+NETTAP_VERSION=${NETTAP_VERSION:-"v0.0.35"}
 
 # generate the helm chart
 echo "generating chart..."
-speedmgmt generate helm "$VERSION" -c nettap="$NETAPP_VERSION" > /dev/null
+speedmgmt generate helm "$VERSION" -c nettap="$NETTAP_VERSION" > /dev/null
 if [[ -z "$VERSION" ]];then
   echo "It looks like you're missing a required binary.  This script is intended for Speedscale engineers.  Use the helm command to interact with charts."
   exit 1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small build-script-only change that fixes an env var typo and updates a fallback version; low likelihood of impacting runtime behavior outside chart generation.
> 
> **Overview**
> Fixes a typo in the `build` script by renaming the env var used for the Nettap chart component version (from `NETAPP_VERSION` to `NETTAP_VERSION`) so overrides work as intended.
> 
> Bumps the default Nettap fallback version from `v0.0.5` to `v0.0.35` and uses that value when calling `speedmgmt generate helm`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 815b8010c5dd91c05f567e8079b315a3b0c9552c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->