### PR TITLE
[S-10981] operator-helm: allow pre-install job overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ helm -n speedscale uninstall speedscale-operator
 kubectl -n speedscale delete job speedscale-operator-pre-install
 ```
 
+If your cluster needs different settings for that hook job than the rest of the chart,
+you can override them with `preInstallJob` values. For example:
+
+```yaml
+preInstallJob:
+  podSecurityContext:
+    runAsNonRoot: false
+    fsGroup: 0
+  containerSecurityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0
+  nodeSelector:
+    kubernetes.io/os: linux
+```
+
 ## Uninstall Chart
 
 ```bash

--- a/charts/2.5.565/README.md
+++ b/charts/2.5.565/README.md
@@ -62,6 +62,22 @@ helm -n speedscale uninstall speedscale-operator
 kubectl -n speedscale delete job speedscale-operator-pre-install
 ```
 
+If your cluster needs different settings for that hook job than the rest of the chart,
+you can override them with `preInstallJob` values. For example:
+
+```yaml
+preInstallJob:
+  podSecurityContext:
+    runAsNonRoot: false
+    fsGroup: 0
+  containerSecurityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0
+  nodeSelector:
+    kubernetes.io/os: linux
+```
+
 ## Uninstall Chart
 
 ```bash

--- a/charts/2.5.565/app-readme.md
+++ b/charts/2.5.565/app-readme.md
@@ -62,6 +62,22 @@ helm -n speedscale uninstall speedscale-operator
 kubectl -n speedscale delete job speedscale-operator-pre-install
 ```
 
+If your cluster needs different settings for that hook job than the rest of the chart,
+you can override them with `preInstallJob` values. For example:
+
+```yaml
+preInstallJob:
+  podSecurityContext:
+    runAsNonRoot: false
+    fsGroup: 0
+  containerSecurityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0
+  nodeSelector:
+    kubernetes.io/os: linux
+```
+
 ## Uninstall Chart
 
 ```bash

--- a/charts/2.5.565/templates/hooks.yaml
+++ b/charts/2.5.565/templates/hooks.yaml
@@ -1,36 +1,63 @@
+{{- $jobAnnotations := mergeOverwrite (deepCopy (default (dict) .Values.globalAnnotations)) (deepCopy (default (dict) .Values.preInstallJob.annotations)) (dict "helm.sh/hook" "pre-install" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" "helm.sh/hook-weight" "4") -}}
+{{- $jobLabels := mergeOverwrite (deepCopy (default (dict) .Values.globalLabels)) (deepCopy (default (dict) .Values.preInstallJob.labels)) -}}
+{{- $podAnnotations := mergeOverwrite (deepCopy (default (dict) .Values.globalAnnotations)) (deepCopy (default (dict) .Values.preInstallJob.podAnnotations)) -}}
+{{- $podLabels := mergeOverwrite (deepCopy (default (dict) .Values.globalLabels)) (deepCopy (default (dict) .Values.preInstallJob.podLabels)) -}}
+{{- $jobImageRegistry := .Values.preInstallJob.image.registry | default .Values.image.registry -}}
+{{- $jobImageTag := .Values.preInstallJob.image.tag | default .Values.image.tag -}}
+{{- $jobImagePullPolicy := .Values.preInstallJob.image.pullPolicy | default .Values.image.pullPolicy -}}
+{{- $jobContainerSecurityContext := .Values.globalPodSecurityContext -}}
+{{- if ne .Values.preInstallJob.containerSecurityContext nil -}}
+{{- $jobContainerSecurityContext = .Values.preInstallJob.containerSecurityContext -}}
+{{- end -}}
+{{- $jobPodSecurityContext := .Values.globalSecurityContext -}}
+{{- if ne .Values.preInstallJob.podSecurityContext nil -}}
+{{- $jobPodSecurityContext = .Values.preInstallJob.podSecurityContext -}}
+{{- end -}}
+{{- $jobAffinity := .Values.affinity -}}
+{{- if ne .Values.preInstallJob.affinity nil -}}
+{{- $jobAffinity = .Values.preInstallJob.affinity -}}
+{{- end -}}
+{{- $jobTolerations := .Values.tolerations -}}
+{{- if ne .Values.preInstallJob.tolerations nil -}}
+{{- $jobTolerations = .Values.preInstallJob.tolerations -}}
+{{- end -}}
+{{- $jobNodeSelector := .Values.nodeSelector -}}
+{{- if ne .Values.preInstallJob.nodeSelector nil -}}
+{{- $jobNodeSelector = .Values.preInstallJob.nodeSelector -}}
+{{- end -}}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   annotations:
-    helm.sh/hook: pre-install
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-    helm.sh/hook-weight: "4"
-    {{- if .Values.globalAnnotations }}
-{{ toYaml .Values.globalAnnotations | indent 4}}
+    {{- if $jobAnnotations }}
+{{ toYaml $jobAnnotations | indent 4}}
     {{- end }}
   creationTimestamp: null
   name: speedscale-operator-pre-install
   namespace: {{ .Release.Namespace }}
   labels:
-  {{- if .Values.globalLabels }}
-{{ toYaml .Values.globalLabels | indent 4}}
+  {{- if $jobLabels }}
+{{ toYaml $jobLabels | indent 4}}
     {{- end }}
 spec:
-  backoffLimit: 0
-  ttlSecondsAfterFinished: 30
+  backoffLimit: {{ .Values.preInstallJob.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.preInstallJob.ttlSecondsAfterFinished }}
   template:
     metadata:
       annotations:
-        {{- if .Values.globalAnnotations }}
-{{ toYaml .Values.globalAnnotations | indent 8}}
+        {{- if $podAnnotations }}
+{{ toYaml $podAnnotations | indent 8}}
         {{- end }}
       creationTimestamp: null
       labels:
-        {{- if .Values.globalLabels }}
-{{ toYaml .Values.globalLabels | indent 8}}
+        {{- if $podLabels }}
+{{ toYaml $podLabels | indent 8}}
         {{- end }}
     spec:
+      {{- if .Values.preInstallJob.serviceAccountName }}
+      serviceAccountName: {{ .Values.preInstallJob.serviceAccountName }}
+      {{- end }}
       containers:
       - args:
         - |-
@@ -59,30 +86,27 @@ spec:
         - secretRef:
             name: '{{ ne .Values.apiKeySecret "" | ternary .Values.apiKeySecret "speedscale-apikey" }}'
             optional: false
-        image: '{{ .Values.image.registry }}/speedscale-cli:{{ .Values.image.tag }}'
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.preInstallJob.extraEnvFrom }}
+{{ toYaml .Values.preInstallJob.extraEnvFrom | nindent 8 }}
+        {{- end }}
+        image: '{{ $jobImageRegistry }}/speedscale-cli:{{ $jobImageTag }}'
+        imagePullPolicy: {{ $jobImagePullPolicy }}
         name: speedscale-cli
         volumeMounts:
         - mountPath: /tmp
           name: tmp
-        securityContext: {{ toYaml .Values.globalPodSecurityContext | nindent 10 }}
-        resources:
-          limits:
-            memory: "128M"
-            cpu: "1"
-          requests:
-            memory: "64M"
-            cpu: "100m"
+        securityContext: {{ toYaml $jobContainerSecurityContext | nindent 10 }}
+        resources: {{ toYaml .Values.preInstallJob.resources | nindent 10 }}
       restartPolicy: Never
-      securityContext: {{ toYaml .Values.globalSecurityContext | nindent 8 }}
-      {{- if .Values.affinity }}
-      affinity: {{ toYaml .Values.affinity | nindent 8 }}
+      securityContext: {{ toYaml $jobPodSecurityContext | nindent 8 }}
+      {{- if $jobAffinity }}
+      affinity: {{ toYaml $jobAffinity | nindent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
-      tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
+      {{- if $jobTolerations }}
+      tolerations: {{ toYaml $jobTolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
+      {{- if $jobNodeSelector }}
+      nodeSelector: {{ toYaml $jobNodeSelector | nindent 8 }}
       {{- end }}
       volumes:
       - name: tmp

--- a/charts/2.5.565/values.yaml
+++ b/charts/2.5.565/values.yaml
@@ -133,6 +133,35 @@ privilegedSidecars: false
 # This job requires a root container user, disable if not needed or security policies forbid `runAsNonRoot: true`
 createJKS: true
 
+# Overrides for the speedscale-operator-pre-install hook job.
+# Job and pod annotations/labels are merged with the global values above.
+# Security context and placement settings fall back to the global values when left unset.
+preInstallJob:
+  annotations: {}
+  labels: {}
+  podAnnotations: {}
+  podLabels: {}
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 30
+  resources:
+    limits:
+      memory: "128M"
+      cpu: "1"
+    requests:
+      memory: "64M"
+      cpu: "100m"
+  image:
+    registry: ""
+    tag: ""
+    pullPolicy: ""
+  containerSecurityContext: null
+  podSecurityContext: null
+  affinity: null
+  tolerations: null
+  nodeSelector: null
+  serviceAccountName: ""
+  extraEnvFrom: []
+
 # control if the sidecar should enable/disable use of the smart dns lookup feature (requires NET_ADMIN)
 disableSidecarSmartReverseDNS: false
 

--- a/values.yaml
+++ b/values.yaml
@@ -133,6 +133,35 @@ privilegedSidecars: false
 # This job requires a root container user, disable if not needed or security policies forbid `runAsNonRoot: true`
 createJKS: true
 
+# Overrides for the speedscale-operator-pre-install hook job.
+# Job and pod annotations/labels are merged with the global values above.
+# Security context and placement settings fall back to the global values when left unset.
+preInstallJob:
+  annotations: {}
+  labels: {}
+  podAnnotations: {}
+  podLabels: {}
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 30
+  resources:
+    limits:
+      memory: "128M"
+      cpu: "1"
+    requests:
+      memory: "64M"
+      cpu: "100m"
+  image:
+    registry: ""
+    tag: ""
+    pullPolicy: ""
+  containerSecurityContext: null
+  podSecurityContext: null
+  affinity: null
+  tolerations: null
+  nodeSelector: null
+  serviceAccountName: ""
+  extraEnvFrom: []
+
 # control if the sidecar should enable/disable use of the smart dns lookup feature (requires NET_ADMIN)
 disableSidecarSmartReverseDNS: false
 


### PR DESCRIPTION
## Summary
This adds `preInstallJob` values so the `speedscale-operator-pre-install` Helm hook job can be configured independently from the chart-wide defaults.

The hook now supports per-job overrides for annotations, labels, pod metadata, resources, security contexts, scheduling controls, image settings, `serviceAccountName`, and extra `envFrom` entries. Explicit empty placement overrides now clear inherited global `affinity`, `tolerations`, and `nodeSelector` settings, while the built-in Helm hook annotations remain protected.

## Verification
- `thoughts/scripts/verify-preinstall-job-overrides.sh`
- `helm lint charts/2.5.565 --set apiKey=dummy --set clusterName=test-cluster`

Linear: S-10981
